### PR TITLE
feat(): Display multiple timezones in the status bar

### DIFF
--- a/scripts/dracula.sh
+++ b/scripts/dracula.sh
@@ -312,11 +312,7 @@ main() {
 
     elif [ $plugin = "time" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-time-colors" "dark_purple white")
-      if $show_military; then
-        script="#($current_dir/dual_time.sh military)"
-      else
-        script="#($current_dir/dual_time.sh)"
-      fi
+      script="#($current_dir/dual_time.sh)"
 
     elif [ $plugin = "synchronize-panes" ]; then
       IFS=' ' read -r -a colors <<<$(get_tmux_option "@dracula-synchronize-panes-colors" "cyan dark_gray")

--- a/scripts/dual_time.sh
+++ b/scripts/dual_time.sh
@@ -1,16 +1,35 @@
 #!/usr/bin/env bash
 
-belfast_label="Belfast"
-belfast_tz="Europe/London"
-newyork_label="New York"
-newyork_tz="America/New_York"
-if [ "$1" = "military" ]; then
+military=$(tmux show-option -gqv "@dracula-time-military" | tr '[:upper:]' '[:lower:]')
+
+time_fmt="%I:%M %p"
+
+if [[ "$military" == "true" || "$military" == "1" ]]; then
   time_fmt="%H:%M"
-else
-  time_fmt="%I:%M %p"
 fi
 
-belfast_time=$(env TZ=$belfast_tz /bin/date +"${belfast_label} ${time_fmt}")
-newyork_time=$(env TZ=$newyork_tz /bin/date +"${newyork_label} ${time_fmt}")
+timezones=$(tmux show-option -gqv "@dracula-time")
+[ -z "$timezones" ] && timezones="UTC"
 
-echo "$belfast_time | $newyork_time"
+IFS=',' read -ra TZ_ARRAY <<<"$timezones"
+
+output=()
+for tz in "${TZ_ARRAY[@]}"; do
+  tz=$(echo "$tz" | xargs) # Trim whitespace
+  label=$(basename "$tz" | tr '_' ' ')
+  if [ -f "/usr/share/zoneinfo/$tz" ]; then
+    time=$(env TZ="$tz" /bin/date +"${label} ${time_fmt}")
+    output+=("$time")
+  else
+    output+=("${label} N/A")
+  fi
+done
+
+joined=""
+for i in "${!output[@]}"; do
+  if [ "$i" -gt 0 ]; then
+    joined+=" | "
+  fi
+  joined+="${output[$i]}"
+done
+echo "$joined"


### PR DESCRIPTION
Display multiple timezones in the status bar and have it dynamically update based on how many you have.

`set -g @dracula-time "Europe/London,America/New_York,Asia/Tokyo"` will display like`London <time> | <New York <time> | Tokyo <time>`
and 
`set -g @dracula-time "Europe/London,America/New_York"` `London <time> | <New York <time>`